### PR TITLE
rosinstall: add examples repository

### DIFF
--- a/rosinstall.yaml
+++ b/rosinstall.yaml
@@ -1,3 +1,6 @@
 - git:
-    uri: https://github.com/rosin-project/rx_ros
-    local-name: rx_ros
+    uri: https://github.com/rosin-project/rxros.git
+    local-name: rxros
+- git:
+    uri: https://github.com/rosin-project/rxros_examples.git
+    local-name: rxros_examples


### PR DESCRIPTION
As per subject.

The examples haven't been moved to `rxros_examples` yet, but that doesn't matter: `wstool` will just clone an empty repository in that case.

As soon as the example packages *have* been moved, the clone will not be empty any longer, and nothing will have to change (as the `.rosinstall` file has already been prepared).
