### PR TITLE
rosinstall: rxcpp_vendor has been released.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ mkdir ~/rxros_ws
 cd ~/rxros_ws
 
 # populate the workspace with rxros packages
-wstool init src https://raw.githubusercontent.com/rosin-project/rxros/master/rxros.rosinstall
+git clone https://github.com/rosin-project/rxros.git src/rxros
 
 # install all required dependencies
 rosdep update

--- a/rxros.rosinstall
+++ b/rxros.rosinstall
@@ -1,6 +1,3 @@
 - git:
     uri: https://github.com/rosin-project/rxros.git
     local-name: rxros
-- git:
-    uri: https://github.com/rosin-project/rxcpp_vendor.git
-    local-name: rxcpp_vendor


### PR DESCRIPTION
As per subject.

Note that this PR should only be merged *after* the next Kinetic sync (as `rxcpp_vendor` is only in [ros-testing](http://wiki.ros.org/TestingRepository) right now.
