### PR TITLE
Issue #15: rxros::spin() function uses unnecessary many threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,18 @@ The other purpose of the rxros::spin function is to dispatch messages from ROS t
 Failure to omit the rxros::spin function will cause the program to terminate immediately and observables based on ROS topics
 will not emit any events.
 
+rxros::spin will per default use one thread for dispatching messages. For most nodes this will be sufficient.
+In special cases where a node uses many topics it may be necessary to use more threads for dispatching messages.
+This can be achieved by specifying the number of threads the rxros::spin function should use.
+A special case is rxros::spin(0) which will allocate a thread for each CPU core.
+ 
 The Example below shows a minimal RxROS program that creates a ROS node named “my_node”.
 The program will due to rxros:spin() continue to run until it is either shutdown or terminated.
 
 ### Syntax
 
 ```cpp
-void rxros::spin();
+void rxros::spin(uint32_t thread_count = 1);
 ```
 
 ### Example

--- a/rxros/include/rxros/rxros.h
+++ b/rxros/include/rxros/rxros.h
@@ -48,8 +48,8 @@ namespace rxros
         ros::init(argc, argv, name);
     }
 
-    static void spin() {
-        ros::MultiThreadedSpinner spinner(0); // Use a spinner for each available CPU core
+    static void spin(uint32_t thread_count = 1) { // Use per default 1 thread for spinning
+        ros::MultiThreadedSpinner spinner(thread_count);
         spinner.spin();
     }
 

--- a/rxros/include/rxros/rxros.h
+++ b/rxros/include/rxros/rxros.h
@@ -44,20 +44,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace rxros
 {
-    static void init(int argc, char** argv, const std::string& name) {
-        ros::init(argc, argv, name);
-    }
-
-    static void spin(uint32_t thread_count = 1) { // Use per default 1 thread for spinning
-        ros::MultiThreadedSpinner spinner(thread_count);
-        spinner.spin();
-    }
-
-    static bool ok() {
-        return ros::ok();
-    }
-
-
     class node: public ros::NodeHandle
     {
     private:
@@ -225,7 +211,7 @@ namespace rxros
                         FD_SET(fd, &readfds);
                         T event{};
                         bool errReported = false;
-                        while (rxros::ok()) {
+                        while (ros::ok()) {
                             int rc = select(fd + 1, &readfds, nullptr, nullptr, nullptr);  // wait for input on keyboard device
                             if (rc == -1 && errno == EINTR) { // select was interrupted. This is not an error but we exit the loop
                                 subscriber.on_completed();

--- a/rxros_tf/include/rxros_tf/rxros_tf.h
+++ b/rxros_tf/include/rxros_tf/rxros_tf.h
@@ -47,7 +47,7 @@ namespace rxros
                     tf::TransformListener transform_listener;
                     ros::Rate rate(frequencyInHz);
                     bool errReported = false;
-                    while (rxros::ok()) {
+                    while (ros::ok()) {
                         try {
                             tf::StampedTransform transform;
                             transform_listener.lookupTransform(parent_frameId, child_frameId, ros::Time(0), transform);


### PR DESCRIPTION
Fix of Issue #15: rxros::spin() function uses unnecessary many threads.
Default is now set to one thread and the programmer can if needed specify more threads by giving an argument to the spin function.