### PR TITLE
Fix #31: RxROS operators should use subscribe_on rather than observe_on

### DIFF
--- a/rxros/include/rxros/rxros.h
+++ b/rxros/include/rxros/rxros.h
@@ -301,7 +301,7 @@ namespace rxros
         auto publish_to_topic(const std::string &topic, const uint32_t queue_size = 10) {
             return [=](auto&& source) {
                 ros::Publisher publisher(rxros::node::get_handle().advertise<T>(topic, queue_size));
-                source.observe_on(rxcpp::synchronize_new_thread()).subscribe(
+                source.subscribe_on(rxcpp::synchronize_new_thread()).subscribe(
                     [=](const T& msg) {publisher.publish(msg);});
                 return source;};}
 

--- a/rxros_tf/include/rxros_tf/rxros_tf.h
+++ b/rxros_tf/include/rxros_tf/rxros_tf.h
@@ -77,7 +77,7 @@ namespace rxros
         auto send_transform() {
             return [=](auto&& source) {
                 tf::TransformBroadcaster transformBroadcaster;
-                source.observe_on(rxcpp::synchronize_new_thread()).subscribe(
+                source.subscribe_on(rxcpp::synchronize_new_thread()).subscribe(
                     [&](const tf::StampedTransform& stf) {transformBroadcaster.sendTransform(stf);});
                 return source;};}
 
@@ -85,7 +85,7 @@ namespace rxros
         auto send_transform(const std::string &parent_frameId, const std::string &child_frameId) {
             return [=](auto&& source) {
                 tf::TransformBroadcaster transformBroadcaster;
-                source.observe_on(rxcpp::synchronize_new_thread()).subscribe(
+                source.subscribe_on(rxcpp::synchronize_new_thread()).subscribe(
                     [&](const tf::Transform& tf) {transformBroadcaster.sendTransform(tf::StampedTransform(tf, ros::Time::now(), parent_frameId, child_frameId));});
                 return source;};}
 


### PR DESCRIPTION
The observe_on call has been changed with the subscribe_on to ensure that the operations are executed in a dedicated thread.